### PR TITLE
Added alert for when users add an invalid or existing username

### DIFF
--- a/res/scripts/main.js
+++ b/res/scripts/main.js
@@ -44,7 +44,7 @@ function storeData(data) {
 function getDetails(username){
     username = username.toLowerCase();
     if (users.has(username) && loadingFinished) {
-        alert(`Username ${username} already exists.`);
+        alert(`Username "${username}" already exists.`);
         return;
     }
     fetch(`https://competitive-coding-api.herokuapp.com/api/codechef/${username}`)
@@ -53,7 +53,7 @@ function getDetails(username){
         function (data) {
             // console.log(data);
             if(data.status === 'Failed' && data.details === 'Invalid username'){
-                alert(`${username} is an invalid username.`);
+                alert(`"${username}" is an invalid username.`);
                 return;
             }
             const information = {


### PR DESCRIPTION
Fix issue #7 

Added an `alert` call to an existing check for when set already contains a submitted username.
Created an `if` check inside the `getDetails` API call's second `then` method to see if the response status is "Failed" with the details "Invalid username", and if this evaluates to `true`, user will be alerted with another `alert` call.