### PR TITLE
Automatically focus on username input whenever menubar is opened

### DIFF
--- a/res/scripts/main.js
+++ b/res/scripts/main.js
@@ -160,7 +160,9 @@ function toggleMenu()
         toggle_icon.classList.add('fa-chevron-up');   
     }
     menu_content.classList.toggle('hide');
-    document.getElementById('username').focus()
+    if (!menu_content.classList.contains('hide')){
+        document.getElementById('username').focus()
+    }
 }
 
 function showAlert(message){


### PR DESCRIPTION
Fixes #34 

`setTimeout` is used so call to `focus` happens after the input element has been revealed.