### PR TITLE
Adding Total Rated Competitions Count entry in CodeChef Cards

### DIFF
--- a/res/scripts/main.js
+++ b/res/scripts/main.js
@@ -123,7 +123,7 @@ function createCard({name, username, rating, highestRating, stars, countryRank, 
     e_countryRank.innerHTML = `Country Rank: ${countryRank}`;
 
     const e_contestsParticipated = document.createElement("p");
-    e_contestsParticipated.innerHTML = `Rated Contests Participation: ${ratedCompetitionsCount}`;
+    e_contestsParticipated.innerHTML = `Rated Contests Participated: ${ratedCompetitionsCount}`;
 
     const e_fullySolved = document.createElement("p");
     e_fullySolved.innerHTML = `Problems Fully Solved: ${fullySolved}`;


### PR DESCRIPTION
This Pull Request just adds an additional information in CodeChef cards, namely "Total Contests Participation" as shown with this card:
![CC-Card-Yash](https://user-images.githubusercontent.com/57865187/138083069-482504d0-13c3-40ef-920e-e8b182ebd4e4.png)

This contests count is included as a count of contests with at least one scorable submission (either fully solved or partially solved) in any contest via count of unique contest codes available via per-contest submissions object through the API in use, and was previously proposed in ending comment of PR #15. The 'Practice' entry has been excluded from the count of total contests, and only unique entries have been considered from "Fully Solved" and "Partially Solved" contest entries.

This is how cards looks, as a sample:
![_C__Users_Devil's%20Lair_Desktop_Temp_Open%20Source_Codechef_Cards_index html](https://user-images.githubusercontent.com/57865187/138083722-699172dc-87a9-49bb-b8d2-c29f31ea9b52.png)

I believe this entry should be included with this useful tool as this count is currently not available even on the CodeChef user handle profile page, which makes it difficult to keep a count of the contests we have successfully participated in so far. Please have a look, and merge it if it seems fine.