### PR TITLE
Show alert modal if username is invalid

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -53,7 +53,7 @@ export default function App() {
 							...previous,
 							visible: true,
 							type: "alert",
-							msg: "User not found!",
+							msg: "You entered Invalid Username.",
 						};
 					});
 					removeUser(username);


### PR DESCRIPTION
Adding an invalid username will cause an alert modal to pop up that displays "User not found!". Also removes the console.log() line that logged this message to the console instead. Resolves #55.